### PR TITLE
Copy directory recursion fix

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Deploystrategy/Copy.php
+++ b/src/MagentoHackathon/Composer/Magento/Deploystrategy/Copy.php
@@ -28,6 +28,12 @@ class Copy extends DeploystrategyAbstract
         $sourcePath = $this->getSourceDir() . '/' . $this->removeTrailingSlash($source);
         $destPath = $this->getDestDir() . '/' . $this->removeTrailingSlash($dest);
 
+        // if the source file is actually a folder, force recursion back into the create method using a glob to copy
+        // all of this folder's contents into the folder at the destination
+        if (is_dir($sourcePath)) {
+            echo "Match {$sourcePath} is a directory, making this a glob pattern and recursing:\n";
+            return $this->create($source.'/*', $dest);
+        }
 
         // Create all directories up to one below the target if they don't exist
         $destDir = dirname($destPath);


### PR DESCRIPTION
Changed the way the `Copy::createDelegate` method handles copying when the source file is actually a folder. Made this recurse back into the `create` method for now, passing the folder as a glob pattern. This is less performant than copying the entire folder at once, but copying the entire folder produces incorrect file paths when the destination folder already exists and copying file-by-file seems the best way to reconcile this so that any pre-existing non-composer-installed files in that folder can remain intact.